### PR TITLE
Fix ingestion workflow and chunking

### DIFF
--- a/app/chunking.py
+++ b/app/chunking.py
@@ -17,7 +17,9 @@ def chunk_text(text: str, out_dir: Path) -> List[Path]:
         path = out_dir / f"chunk_{idx}.txt"
         path.write_text(chunk)
         chunks.append(path)
-        start = end - OVERLAP
+        if end == len(text):
+            break
+        start = max(0, end - OVERLAP)
         idx += 1
     manifest = out_dir / 'manifest.ndjson'
     with manifest.open('w') as f:

--- a/app/parsing.py
+++ b/app/parsing.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 from typing import Optional
 
-from docx import Document
 from openpyxl import load_workbook
+try:  # pragma: no cover - python-docx optional
+    from docx import Document
+except Exception:  # pragma: no cover
+    Document = None
 try:  # pragma: no cover - pillow optional
     from PIL import Image
 except Exception:  # pragma: no cover
@@ -11,15 +14,16 @@ except Exception:  # pragma: no cover
 
 def parse_pdf(path: Path) -> str:
     try:
-        data = path.read_bytes()
-        if b"hello" in data.lower():
-            return "hello pdf"
+        from pypdf import PdfReader
+        reader = PdfReader(str(path))
+        return "".join(page.extract_text() or "" for page in reader.pages)
     except Exception:  # pragma: no cover
-        pass
-    return ""
+        return ""
 
 
 def parse_docx(path: Path) -> str:
+    if not Document:
+        return ""
     doc = Document(str(path))
     return "\n".join(p.text for p in doc.paragraphs)
 


### PR DESCRIPTION
## Summary
- avoid sqlite locking by committing before indexing chunks
- create uploads directory and add safe chunking logic
- improve PDF parsing with `pypdf`
- make docx parsing optional when `python-docx` is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be2114fa6c83228a49a61ca27d7459