### PR TITLE
chore: compile desktop typescript before electron build

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,10 +1,11 @@
 {
   "name": "sa-cms-pro-desktop",
   "version": "0.1.0",
-  "main": "electron-main.js",
+  "main": "dist/electron-main.js",
   "scripts": {
     "dev": "ts-node electron-main.ts",
-    "build": "electron-builder"
+    "compile": "tsc --project tsconfig.json",
+    "build": "npm run compile && electron-builder"
   },
   "devDependencies": {
     "electron": "^25.2.0",

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["electron-main.ts", "preload.ts"]
+}


### PR DESCRIPTION
## Summary
- add a TypeScript configuration for the desktop app that emits JavaScript into the dist folder
- run the compile step before electron-builder and update the Electron entry points to use the compiled output

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d0cb29b11c8322bb3ef9163eff397b