### PR TITLE
Restore frontend shell and estimator

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" class="bg-surface-base">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#6366f1" />
+    <title>Signal Advantage Control Center</title>
+    <meta
+      name="description"
+      content="Signal Advantage Copilot workspace for intake, estimating, and program orchestration."
+    />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  </head>
+  <body class="bg-surface-base text-text-primary">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@playwright/test": "^1.55.0",
     "@tailwindcss/postcss": "^4.1.13",
+    "@types/node": "^24.5.2",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.6.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.13
         version: 4.1.13
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.5.2
       '@types/react':
         specifier: ^18.3.5
         version: 18.3.24
@@ -50,7 +53,7 @@ importers:
         version: 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.2
-        version: 4.7.0(vite@5.4.20(lightningcss@1.30.1))
+        version: 4.7.0(vite@5.4.20(@types/node@24.5.2)(lightningcss@1.30.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
@@ -74,7 +77,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: ^5.4.5
-        version: 5.4.20(lightningcss@1.30.1)
+        version: 5.4.20(@types/node@24.5.2)(lightningcss@1.30.1)
 
 packages:
 
@@ -636,6 +639,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@24.5.2':
+    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1634,6 +1640,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.12.0:
+    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
+
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -2181,6 +2190,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@24.5.2':
+    dependencies:
+      undici-types: 7.12.0
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.24)':
@@ -2285,7 +2298,7 @@ snapshots:
       '@typescript-eslint/types': 8.44.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.20(lightningcss@1.30.1))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.20(@types/node@24.5.2)(lightningcss@1.30.1))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -2293,7 +2306,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.20(lightningcss@1.30.1)
+      vite: 5.4.20(@types/node@24.5.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3187,6 +3200,8 @@ snapshots:
 
   typescript@5.9.2: {}
 
+  undici-types@7.12.0: {}
+
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
       browserslist: 4.26.2
@@ -3199,12 +3214,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@5.4.20(lightningcss@1.30.1):
+  vite@5.4.20(@types/node@24.5.2)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.52.0
     optionalDependencies:
+      '@types/node': 24.5.2
       fsevents: 2.3.3
       lightningcss: 1.30.1
 

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,4 +1,4 @@
-import tailwindcss from "@tailwindcss/postcss";
+import tailwindcss from "tailwindcss";
 import autoprefixer from "autoprefixer";
 
 export default {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -580,6 +580,32 @@ function formatStage(status?: string | null): string {
 
 }
 
+function formatBytes(size?: number | null): string {
+  if (!Number.isFinite(size ?? 0) || !size || size <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = size;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  const digits = value >= 10 ? 0 : 1;
+  return `${value.toFixed(digits)} ${units[index]}`;
+}
+
+function formatTimestamp(value?: string | null): string {
+  if (!value) {
+    return "-";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString();
+}
+
 
 
 
@@ -1178,7 +1204,7 @@ export default function App(): JSX.Element {
 
 
 
-      const summary = await launchIntake(projectId, zipPath);
+      const summary = await launchIntake({ projectId, zipPath, orgId: activeOrgId });
 
 
 
@@ -2396,7 +2422,7 @@ const intakeView = (
 
 
 
-                          {new Date(item.updated_at).toLocaleString()}
+                          {formatTimestamp(item.updated_at)}
 
 
 
@@ -2768,7 +2794,7 @@ const intakeView = (
 
 
 
-                          {selectedItem ? new Date(selectedItem.updated_at).toLocaleString() : "-"}
+                          {selectedItem?.updated_at ? formatTimestamp(selectedItem.updated_at) : "-"}
 
 
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from "axios";
 
 export interface IntakeFileItem {
   id: string;
@@ -274,11 +274,15 @@ export function getAccessToken(): string | null {
 const apiClient = axios.create({ baseURL: API_BASE });
 const platformClient = axios.create({ baseURL: `${API_BASE}/platform` });
 
-const attachAuthHeader = (config: Parameters<typeof apiClient.interceptors.request.use>[0]) => {
+const attachAuthHeader = (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
   const token = getAccessToken();
   if (token) {
-    config.headers = config.headers ?? {};
-    config.headers.Authorization = `Bearer ${token}`;
+    const headers =
+      config.headers instanceof AxiosHeaders
+        ? config.headers
+        : new AxiosHeaders(config.headers ?? {});
+    headers.set("Authorization", `Bearer ${token}`);
+    config.headers = headers;
   }
   return config;
 };

--- a/frontend/src/components/estimating/EstimatingPanel.tsx
+++ b/frontend/src/components/estimating/EstimatingPanel.tsx
@@ -1,0 +1,522 @@
+import clsx from "clsx";
+import {
+  CheckCircle2,
+  CircleDashed,
+  ClipboardList,
+  Loader2,
+  Plus,
+  RefreshCcw,
+  Sparkles,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  adjustEstimatorScenario,
+  createEstimatorScenario,
+  fetchEstimatorSummary,
+  mineEstimatorScope,
+  updateWbsItem,
+  type EstimatorSummary,
+  type Scenario,
+  type WbsItem,
+} from "../../api";
+
+export interface EstimatingPanelProps {
+  className?: string;
+  orgId: string;
+  projectId: string;
+}
+
+const panelClasses = "rounded-2xl border border-border-subtle bg-surface-elevated shadow-panel";
+
+function formatCurrency(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "-";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value < 1000 ? 0 : 0,
+  }).format(value);
+}
+
+function collectTotals(
+  totals: Scenario["totals"],
+  prefix = "",
+  acc: Array<{ label: string; value: number }> = [],
+): Array<{ label: string; value: number }> {
+  if (!totals) {
+    return acc;
+  }
+  if (typeof totals === "number") {
+    acc.push({ label: prefix || "Total", value: totals });
+    return acc;
+  }
+  Object.entries(totals).forEach(([key, value]) => {
+    const nextLabel = prefix ? `${prefix} · ${key}` : key;
+    if (typeof value === "number") {
+      acc.push({ label: nextLabel, value });
+    } else if (value && typeof value === "object") {
+      collectTotals(value as Scenario["totals"], nextLabel, acc);
+    }
+  });
+  return acc;
+}
+
+export function EstimatingPanel({ className, orgId, projectId }: EstimatingPanelProps): JSX.Element {
+  const [summary, setSummary] = useState<EstimatorSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mining, setMining] = useState(false);
+  const [creatingScenario, setCreatingScenario] = useState(false);
+  const [savingScenario, setSavingScenario] = useState(false);
+  const [scenarioName, setScenarioName] = useState("Copilot scenario");
+  const [activeScenarioId, setActiveScenarioId] = useState<string | null>(null);
+  const [scenarioTitle, setScenarioTitle] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function hydrate() {
+      try {
+        setLoading(true);
+        setError(null);
+        const payload = await fetchEstimatorSummary(orgId, projectId);
+        if (cancelled) {
+          return;
+        }
+        setSummary(payload);
+        const firstScenario = payload.scenarios[0];
+        setActiveScenarioId(firstScenario ? firstScenario.id : null);
+        setScenarioTitle(firstScenario ? firstScenario.name : "");
+      } catch (cause) {
+        if (!cancelled) {
+          const message = cause instanceof Error ? cause.message : "Unable to load estimator summary";
+          setError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    if (orgId && projectId) {
+      hydrate();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, projectId]);
+
+  useEffect(() => {
+    const scenario = summary?.scenarios.find((entry) => entry.id === activeScenarioId);
+    setScenarioTitle(scenario ? scenario.name : "");
+  }, [summary, activeScenarioId]);
+
+  const activeScenario = useMemo(
+    () => summary?.scenarios.find((scenario) => scenario.id === activeScenarioId) ?? null,
+    [summary, activeScenarioId],
+  );
+
+  const scopeAccepted = summary?.wbs.filter((item) => item.accepted).length ?? 0;
+
+  const scenarioTotals = useMemo(() => {
+    if (!activeScenario) {
+      return [];
+    }
+    return collectTotals(activeScenario.totals);
+  }, [activeScenario]);
+
+  const handleRefresh = async () => {
+    try {
+      setLoading(true);
+      const payload = await fetchEstimatorSummary(orgId, projectId);
+      setSummary(payload);
+      if (payload.scenarios.length > 0) {
+        setActiveScenarioId(payload.scenarios[0].id);
+      }
+      toast.success("Estimator synchronized");
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Unable to refresh estimator";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMineScope = async () => {
+    try {
+      setMining(true);
+      const items = await mineEstimatorScope(orgId, projectId);
+      setSummary((previous) => {
+        if (previous) {
+          return { ...previous, wbs: items };
+        }
+        return {
+          org_id: orgId,
+          project_id: projectId,
+          wbs: items,
+          rates: [],
+          scenarios: [],
+        };
+      });
+      toast.success(`Scope mined for ${items.length} segments`);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Scope mining failed";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setMining(false);
+    }
+  };
+
+  const toggleItemAcceptance = async (item: WbsItem) => {
+    const next = !item.accepted;
+    setSummary((previous) => {
+      if (!previous) {
+        return previous;
+      }
+      return {
+        ...previous,
+        wbs: previous.wbs.map((entry) => (entry.id === item.id ? { ...entry, accepted: next } : entry)),
+      };
+    });
+
+    try {
+      const updated = await updateWbsItem(item.id, { accepted: next });
+      setSummary((previous) => {
+        if (!previous) {
+          return previous;
+        }
+        return {
+          ...previous,
+          wbs: previous.wbs.map((entry) => (entry.id === updated.id ? updated : entry)),
+        };
+      });
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Unable to update WBS item";
+      toast.error(message);
+      setSummary((previous) => {
+        if (!previous) {
+          return previous;
+        }
+        return {
+          ...previous,
+          wbs: previous.wbs.map((entry) => (entry.id === item.id ? item : entry)),
+        };
+      });
+    }
+  };
+
+  const handleScenarioSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = scenarioName.trim();
+    if (!trimmed) {
+      toast.error("Enter a scenario name");
+      return;
+    }
+    try {
+      setCreatingScenario(true);
+      const scenario = await createEstimatorScenario({ org_id: orgId, project_id: projectId, name: trimmed });
+      setSummary((previous) => {
+        if (previous) {
+          return { ...previous, scenarios: [...previous.scenarios, scenario] };
+        }
+        return {
+          org_id: orgId,
+          project_id: projectId,
+          wbs: [],
+          rates: [],
+          scenarios: [scenario],
+        };
+      });
+      setActiveScenarioId(scenario.id);
+      setScenarioName("Copilot scenario");
+      toast.success("Scenario created");
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Unable to create scenario";
+      toast.error(message);
+    } finally {
+      setCreatingScenario(false);
+    }
+  };
+
+  const handleScenarioRename = async () => {
+    if (!activeScenario) {
+      return;
+    }
+    const trimmed = scenarioTitle.trim();
+    if (!trimmed || trimmed === activeScenario.name) {
+      return;
+    }
+    try {
+      setSavingScenario(true);
+      const updated = await adjustEstimatorScenario(activeScenario.id, { name: trimmed });
+      setSummary((previous) => {
+        if (!previous) {
+          return previous;
+        }
+        return {
+          ...previous,
+          scenarios: previous.scenarios.map((scenario) => (scenario.id === updated.id ? updated : scenario)),
+        };
+      });
+      toast.success("Scenario renamed");
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Unable to update scenario";
+      toast.error(message);
+    } finally {
+      setSavingScenario(false);
+    }
+  };
+
+  const headerActions = (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={handleRefresh}
+        className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-xs font-semibold text-text-secondary shadow-panel transition hover:-translate-y-0.5 hover:bg-surface-muted"
+      >
+        <RefreshCcw className="h-3.5 w-3.5" /> Sync summary
+      </button>
+      <button
+        type="button"
+        onClick={handleMineScope}
+        disabled={mining}
+        className="inline-flex items-center gap-2 rounded-full border border-accent/50 bg-accent px-3 py-1.5 text-xs font-semibold text-accent-contrast shadow-panel transition hover:-translate-y-0.5 hover:bg-accent/90 disabled:opacity-60"
+      >
+        {mining ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />} Mine scope
+      </button>
+    </div>
+  );
+
+  return (
+    <section className={clsx("space-y-6", className)}>
+      <header className={clsx(panelClasses, "p-6 sm:p-8")} aria-label="Estimator overview">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-tertiary">Estimating Copilot</p>
+            <h2 className="mt-2 text-xl font-semibold text-text-primary">Scenario planning workspace</h2>
+            <p className="mt-1 max-w-2xl text-sm text-text-secondary">
+              Mine work breakdown segments, align rate cards, and collaborate with the estimating copilot to evolve pricing scenarios before committing exports downstream.
+            </p>
+          </div>
+          {headerActions}
+        </div>
+        <div className="mt-6 grid gap-4 text-xs text-text-secondary sm:grid-cols-3">
+          <div className="rounded-xl border border-border-subtle bg-surface px-4 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Scope accepted</p>
+            <p className="mt-1 text-lg font-semibold text-text-primary">
+              {scopeAccepted} / {summary?.wbs.length ?? 0}
+            </p>
+          </div>
+          <div className="rounded-xl border border-border-subtle bg-surface px-4 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Rate entries</p>
+            <p className="mt-1 text-lg font-semibold text-text-primary">{summary?.rates.length ?? 0}</p>
+          </div>
+          <div className="rounded-xl border border-border-subtle bg-surface px-4 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Scenarios</p>
+            <p className="mt-1 text-lg font-semibold text-text-primary">{summary?.scenarios.length ?? 0}</p>
+          </div>
+        </div>
+        {error ? <p className="mt-4 text-sm text-danger">{error}</p> : null}
+        {loading ? (
+          <div className="mt-6 inline-flex items-center gap-3 text-sm text-text-secondary">
+            <Loader2 className="h-4 w-4 animate-spin" /> Hydrating estimator…
+          </div>
+        ) : null}
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className={clsx(panelClasses, "p-6")} aria-label="Work breakdown structure">
+          <header className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold text-text-primary">Work breakdown</h3>
+              <p className="text-xs text-text-secondary">Accept or refine segments prior to pricing.</p>
+            </div>
+            <span className="inline-flex items-center gap-2 rounded-full bg-accent-soft px-3 py-1 text-xs font-semibold text-accent">
+              <ClipboardList className="h-3.5 w-3.5" /> Copilot suggestions
+            </span>
+          </header>
+          <div className="mt-4 space-y-3">
+            {summary?.wbs.length ? (
+              summary.wbs.map((item) => {
+                const accepted = item.accepted;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => toggleItemAcceptance(item)}
+                    className={clsx(
+                      "w-full rounded-xl border px-4 py-3 text-left shadow-panel transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                      accepted
+                        ? "border-success/40 bg-success-soft/80 text-text-primary"
+                        : "border-border-subtle bg-surface text-text-secondary hover:bg-surface-muted",
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-text-primary">{item.code} · {item.description}</p>
+                        <p className="mt-1 text-xs text-text-secondary">Confidence {Math.round(item.confidence * 100)}%</p>
+                      </div>
+                      {accepted ? (
+                        <CheckCircle2 className="h-4 w-4 text-success" aria-hidden />
+                      ) : (
+                        <CircleDashed className="h-4 w-4 text-text-tertiary" aria-hidden />
+                      )}
+                    </div>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="rounded-xl border border-border-subtle border-dashed bg-surface px-4 py-6 text-center text-sm text-text-secondary">
+                No scope mined yet. Trigger copilot mining to draft the breakdown.
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className={clsx(panelClasses, "p-6 space-y-4")} aria-label="Rate library">
+          <header className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold text-text-primary">Rate intelligence</h3>
+              <p className="text-xs text-text-secondary">Crew and material ranges surfaced by copilot.</p>
+            </div>
+          </header>
+          {summary?.rates.length ? (
+            <div className="space-y-3">
+              {summary.rates.map((rate) => (
+                <div key={rate.id} className="rounded-xl border border-border-subtle bg-surface px-4 py-3 shadow-panel">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-semibold text-text-primary">{rate.category}</p>
+                      {rate.csi_code ? <p className="text-xs text-text-secondary">CSI {rate.csi_code}</p> : null}
+                    </div>
+                    <div className="text-right text-xs text-text-secondary">
+                      <p>Low {formatCurrency(rate.low_rate)}</p>
+                      <p>Base {formatCurrency(rate.base_rate)}</p>
+                      <p>High {formatCurrency(rate.high_rate)}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-border-subtle border-dashed bg-surface px-4 py-6 text-center text-sm text-text-secondary">
+              Rate cards load here after the first platform sync.
+            </div>
+          )}
+        </section>
+      </div>
+
+      <section className={clsx(panelClasses, "p-6 space-y-5")} aria-label="Scenario cockpit">
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-text-primary">Scenarios</h3>
+            <p className="text-xs text-text-secondary">Iterate pricing blends and share with downstream estimators.</p>
+          </div>
+          <form className="flex flex-wrap items-center gap-2" onSubmit={handleScenarioSubmit}>
+            <input
+              type="text"
+              value={scenarioName}
+              onChange={(event) => setScenarioName(event.target.value)}
+              className="w-48 rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-xs text-text-primary shadow-inner focus:border-accent focus:outline-none"
+              placeholder="Scenario name"
+            />
+            <button
+              type="submit"
+              disabled={creatingScenario}
+              className="inline-flex items-center gap-2 rounded-full border border-accent/50 bg-accent px-3 py-1.5 text-xs font-semibold text-accent-contrast shadow-panel transition hover:-translate-y-0.5 hover:bg-accent/90 disabled:opacity-60"
+            >
+              {creatingScenario ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />} New scenario
+            </button>
+          </form>
+        </header>
+        <div className="flex flex-wrap items-center gap-2">
+          {summary?.scenarios.length ? (
+            summary.scenarios.map((scenario) => (
+              <button
+                key={scenario.id}
+                type="button"
+                onClick={() => setActiveScenarioId(scenario.id)}
+                className={clsx(
+                  "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold shadow-panel transition",
+                  scenario.id === activeScenarioId
+                    ? "border-accent/60 bg-accent text-accent-contrast"
+                    : "border-border-subtle bg-surface text-text-secondary hover:bg-surface-muted",
+                )}
+              >
+                {scenario.name}
+              </button>
+            ))
+          ) : (
+            <span className="text-xs text-text-secondary">Copilot will list scenarios here after creation.</span>
+          )}
+        </div>
+        {activeScenario ? (
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="space-y-3">
+              <label className="block text-xs font-semibold uppercase tracking-[0.3em] text-text-tertiary" htmlFor="scenario-title">
+                Scenario title
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="scenario-title"
+                  type="text"
+                  value={scenarioTitle}
+                  onChange={(event) => setScenarioTitle(event.target.value)}
+                  className="w-full rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-sm text-text-primary shadow-inner focus:border-accent focus:outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={handleScenarioRename}
+                  disabled={savingScenario}
+                  className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-xs font-semibold text-text-secondary shadow-panel transition hover:bg-surface-muted disabled:opacity-60"
+                >
+                  {savingScenario ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Save"}
+                </button>
+              </div>
+              <div className="rounded-xl border border-border-subtle bg-surface px-4 py-3 text-xs text-text-secondary shadow-panel">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Markups</p>
+                <dl className="mt-2 space-y-1">
+                  {Object.entries(activeScenario.markup_summary ?? {}).map(([key, value]) => (
+                    <div key={key} className="flex items-center justify-between gap-2">
+                      <dt className="text-xs text-text-secondary">{key}</dt>
+                      <dd className="text-xs font-semibold text-text-primary">{formatCurrency(Number(value))}</dd>
+                    </div>
+                  ))}
+                  {Object.keys(activeScenario.markup_summary ?? {}).length === 0 ? (
+                    <p>No markups recorded yet.</p>
+                  ) : null}
+                </dl>
+              </div>
+            </div>
+            <div className="rounded-xl border border-border-subtle bg-surface px-4 py-3 shadow-panel">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Totals</p>
+              <dl className="mt-2 space-y-1 text-xs text-text-secondary">
+                {scenarioTotals.length ? (
+                  scenarioTotals.map((entry) => (
+                    <div key={entry.label} className="flex items-center justify-between gap-2">
+                      <dt>{entry.label}</dt>
+                      <dd className="font-semibold text-text-primary">{formatCurrency(entry.value)}</dd>
+                    </div>
+                  ))
+                ) : (
+                  <p>Totals will populate once cost models sync.</p>
+                )}
+              </dl>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-border-subtle border-dashed bg-surface px-4 py-6 text-center text-sm text-text-secondary">
+            Select a scenario to view copilot analysis.
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1,0 +1,218 @@
+import clsx from "clsx";
+import { Moon, Sun } from "lucide-react";
+import { type ReactNode } from "react";
+
+export type AppShellTone = "default" | "success" | "warning" | "danger";
+
+export interface AppShellNavItem {
+  id: string;
+  label: string;
+  description: string;
+  icon: ReactNode;
+  badge?: string | ReactNode;
+  tone?: AppShellTone;
+}
+
+export interface AppShellProfile {
+  name: string;
+  code: string;
+  stage?: string;
+}
+
+export interface AppShellUser {
+  name: string;
+  title?: string;
+  initials: string;
+}
+
+export interface AppShellProps {
+  children: ReactNode;
+  navItems: AppShellNavItem[];
+  activeItem: string;
+  onSelect: (id: string) => void;
+  theme: "light" | "dark";
+  onToggleTheme: () => void;
+  user: AppShellUser;
+  org: AppShellProfile;
+  project: AppShellProfile;
+  rightRail?: ReactNode;
+}
+
+function badgeToneClasses(tone: AppShellTone = "default"): string {
+  switch (tone) {
+    case "success":
+      return "bg-success-soft text-success border-success/30";
+    case "warning":
+      return "bg-warning-soft text-warning border-warning/30";
+    case "danger":
+      return "bg-danger-soft text-danger border-danger/30";
+    default:
+      return "bg-surface-muted text-text-secondary border-border-subtle";
+  }
+}
+
+function NavItem({
+  item,
+  active,
+  onSelect,
+}: {
+  item: AppShellNavItem;
+  active: boolean;
+  onSelect: (id: string) => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.id)}
+      className={clsx(
+        "group w-full rounded-xl border border-transparent px-3 py-2 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+        active ? "bg-surface-elevated/90 text-text-primary shadow-panel" : "hover:bg-surface-muted text-text-secondary",
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <span
+          className={clsx(
+            "flex h-9 w-9 items-center justify-center rounded-lg border text-accent",
+            active ? "border-accent/60 bg-accent/10" : "border-border-subtle bg-surface",
+          )}
+        >
+          {item.icon}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className={clsx("truncate text-sm font-semibold", active ? "text-text-primary" : "text-text-secondary")}>{
+              item.label
+            }</p>
+            {item.badge ? (
+              <span
+                className={clsx(
+                  "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  badgeToneClasses(item.tone ?? "default"),
+                )}
+              >
+                {item.badge}
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-0.5 text-xs text-text-tertiary">{item.description}</p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function UserBadge({ user }: { user: AppShellUser }): JSX.Element {
+  const initials = user.initials || user.name.slice(0, 2).toUpperCase();
+  return (
+    <div className="flex items-center gap-3 rounded-full border border-border-subtle bg-surface px-3 py-1.5 shadow-panel">
+      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-accent text-sm font-semibold text-accent-contrast">
+        {initials}
+      </span>
+      <div className="leading-tight">
+        <p className="text-sm font-semibold text-text-primary">{user.name}</p>
+        {user.title ? <p className="text-xs text-text-tertiary">{user.title}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+function OrgProjectSummary({
+  org,
+  project,
+}: {
+  org: AppShellProfile;
+  project: AppShellProfile;
+}): JSX.Element {
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <div>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Organization</p>
+        <p className="text-sm font-semibold text-text-primary">{org.name}</p>
+        <p className="text-xs text-text-secondary">{org.code}</p>
+      </div>
+      <div className="hidden h-10 w-px bg-border-subtle sm:block" aria-hidden />
+      <div>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Project</p>
+        <p className="text-sm font-semibold text-text-primary">{project.name}</p>
+        <p className="text-xs text-text-secondary">{project.code}</p>
+      </div>
+      {project.stage ? (
+        <div className="hidden h-10 w-px bg-border-subtle sm:block" aria-hidden />
+      ) : null}
+      {project.stage ? (
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-text-tertiary">Stage</p>
+          <p className="text-sm font-semibold text-text-primary">{project.stage}</p>
+          <p className="text-xs text-text-secondary">Operational Copilot ready</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function AppShell({
+  children,
+  navItems,
+  activeItem,
+  onSelect,
+  theme,
+  onToggleTheme,
+  user,
+  org,
+  project,
+  rightRail,
+}: AppShellProps): JSX.Element {
+  return (
+    <div className="min-h-screen bg-surface-base text-text-primary">
+      <div className="flex min-h-screen">
+        <aside className="hidden w-72 flex-shrink-0 flex-col border-r border-border-subtle bg-surface-muted/60 px-4 py-6 lg:flex">
+          <div className="space-y-6">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-text-tertiary">Signal Advantage</p>
+              <h1 className="mt-2 text-lg font-semibold text-text-primary">Control Center</h1>
+              <p className="text-xs text-text-secondary">
+                Navigate estimating, intake, and operations modules with copilot overlays.
+              </p>
+            </div>
+            <nav className="space-y-2">
+              {navItems.map((item) => (
+                <NavItem key={item.id} item={item} active={item.id === activeItem} onSelect={onSelect} />
+              ))}
+            </nav>
+          </div>
+          <div className="mt-auto pt-8">
+            <UserBadge user={user} />
+          </div>
+        </aside>
+        <div className="flex min-h-screen flex-1 flex-col">
+          <header className="border-b border-border-subtle bg-surface-elevated/90 px-4 py-4 shadow-shell sm:px-8">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <OrgProjectSummary org={org} project={project} />
+              <div className="flex items-center justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={onToggleTheme}
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border-subtle bg-surface shadow-panel transition hover:-translate-y-0.5 hover:bg-surface-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  aria-label="Toggle theme"
+                >
+                  {theme === "dark" ? <Sun className="h-5 w-5" aria-hidden /> : <Moon className="h-5 w-5" aria-hidden />}
+                </button>
+                <div className="lg:hidden">
+                  <UserBadge user={user} />
+                </div>
+              </div>
+            </div>
+          </header>
+          <div className="flex flex-1 flex-col bg-surface">
+            <div className={clsx("mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-4 py-8 lg:flex-row lg:px-8")}> 
+              <main className={clsx("flex-1", rightRail ? "lg:max-w-4xl" : "max-w-5xl")}>{children}</main>
+              {rightRail ? (
+                <aside className="hidden w-full max-w-sm flex-shrink-0 space-y-4 lg:block">{rightRail}</aside>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/upload/UploadPanel.tsx
+++ b/frontend/src/components/upload/UploadPanel.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Check, Loader2, Trash2, UploadCloud, X } from "lucide-react";
+import { Loader2, Trash2, UploadCloud, X } from "lucide-react";
 
 export type UploadStatus = "queued" | "uploading" | "success" | "error";
 
@@ -16,6 +16,7 @@ export interface UploadItem {
 
 export interface UploadPanelProps {
   className?: string;
+  projectId?: string;
 }
 
 interface ActiveUploadController {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,74 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  --color-surface-base: 244 247 254;
+  --color-surface: 255 255 255;
+  --color-surface-muted: 244 246 252;
+  --color-surface-elevated: 255 255 255;
+  --color-surface-inset: 226 232 240;
+  --color-text-primary: 17 24 39;
+  --color-text-secondary: 71 85 105;
+  --color-text-tertiary: 100 116 139;
+  --color-accent: 99 102 241;
+  --color-accent-contrast: 239 244 255;
+  --color-accent-soft: 226 230 255;
+  --color-success: 34 197 94;
+  --color-success-soft: 220 252 231;
+  --color-warning: 245 158 11;
+  --color-warning-soft: 254 243 199;
+  --color-danger: 239 68 68;
+  --color-danger-soft: 254 226 226;
+  --color-border-subtle: 219 226 239;
+  --color-border-strong: 148 163 184;
+  --color-brand-500: 14 165 233;
+  --color-brand-700: 12 105 175;
+  --shadow-panel: 0 18px 36px -24px rgba(15, 23, 42, 0.35), 0 12px 24px -26px rgba(15, 23, 42, 0.25);
+  --shadow-shell: 0 30px 80px -45px rgba(15, 23, 42, 0.55);
+}
+
+.dark {
+  color-scheme: dark;
+  --color-surface-base: 11 15 23;
+  --color-surface: 18 24 32;
+  --color-surface-muted: 26 33 44;
+  --color-surface-elevated: 33 42 55;
+  --color-surface-inset: 56 68 88;
+  --color-text-primary: 226 232 240;
+  --color-text-secondary: 165 180 197;
+  --color-text-tertiary: 129 140 153;
+  --color-accent: 129 140 248;
+  --color-accent-contrast: 15 23 42;
+  --color-accent-soft: 64 72 120;
+  --color-success: 74 222 128;
+  --color-success-soft: 34 197 94;
+  --color-warning: 252 211 77;
+  --color-warning-soft: 250 204 21;
+  --color-danger: 248 113 113;
+  --color-danger-soft: 127 29 29;
+  --color-border-subtle: 45 55 72;
+  --color-border-strong: 71 85 105;
+  --color-brand-500: 56 189 248;
+  --color-brand-700: 14 165 233;
+  --shadow-panel: 0 18px 36px -28px rgba(2, 6, 23, 0.7), 0 12px 24px -32px rgba(15, 23, 42, 0.55);
+  --shadow-shell: 0 35px 120px -60px rgba(2, 6, 23, 0.75);
+}
+
+@layer base {
+  * {
+    @apply antialiased;
+  }
+
+  body {
+    @apply bg-surface-base text-text-primary;
+    font-family: "Inter", "SF Pro Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+    min-height: 100vh;
+  }
+
+  ::selection {
+    background-color: rgb(var(--color-accent) / 0.2);
+  }
+}
+

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,55 @@
+import { type Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: ["./index.html", "./tailwind-probe.html", "./src/**/*.{ts,tsx,html}"],
+  theme: {
+    extend: {
+      colors: {
+        "surface-base": "rgb(var(--color-surface-base) / <alpha-value>)",
+        surface: "rgb(var(--color-surface) / <alpha-value>)",
+        "surface-muted": "rgb(var(--color-surface-muted) / <alpha-value>)",
+        "surface-elevated": "rgb(var(--color-surface-elevated) / <alpha-value>)",
+        "surface-inset": "rgb(var(--color-surface-inset) / <alpha-value>)",
+        accent: "rgb(var(--color-accent) / <alpha-value>)",
+        "accent-contrast": "rgb(var(--color-accent-contrast) / <alpha-value>)",
+        "accent-soft": "rgb(var(--color-accent-soft) / <alpha-value>)",
+        success: "rgb(var(--color-success) / <alpha-value>)",
+        "success-soft": "rgb(var(--color-success-soft) / <alpha-value>)",
+        warning: "rgb(var(--color-warning) / <alpha-value>)",
+        "warning-soft": "rgb(var(--color-warning-soft) / <alpha-value>)",
+        danger: "rgb(var(--color-danger) / <alpha-value>)",
+        "danger-soft": "rgb(var(--color-danger-soft) / <alpha-value>)",
+        "border-subtle": "rgb(var(--color-border-subtle) / <alpha-value>)",
+        "border-strong": "rgb(var(--color-border-strong) / <alpha-value>)",
+        "text-primary": "rgb(var(--color-text-primary) / <alpha-value>)",
+        "text-secondary": "rgb(var(--color-text-secondary) / <alpha-value>)",
+        "text-tertiary": "rgb(var(--color-text-tertiary) / <alpha-value>)",
+        brand: {
+          500: "rgb(var(--color-brand-500) / <alpha-value>)",
+          700: "rgb(var(--color-brand-700) / <alpha-value>)",
+        },
+      },
+      fontFamily: {
+        sans: [
+          "Inter",
+          "SF Pro Text",
+          "Segoe UI",
+          "system-ui",
+          "-apple-system",
+          "sans-serif",
+        ],
+      },
+      boxShadow: {
+        panel: "var(--shadow-panel)",
+        shell: "var(--shadow-shell)",
+      },
+      borderRadius: {
+        xl: "1rem",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "tests", "tailwind.config.ts", "vite.config.ts", "postcss.config.js"],
+  "references": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,29 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "0.0.0.0",
+    port: 5173,
+  },
+  preview: {
+    host: "0.0.0.0",
+    port: 4173,
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+    },
+  },
+  build: {
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        "tailwind-probe": resolve(__dirname, "tailwind-probe.html"),
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- rebuild the branded application shell with navigation badges, theme controls, and support for right-rail content so the workspace renders again
- implement the estimating panel to hydrate scope, rate, and scenario data from the platform APIs with mining, creation, and rename workflows wired to the toast system
- restore the Vite/Tailwind toolchain (index.html, Tailwind theme tokens, TypeScript config, postcss) and tighten auth helpers plus upload typing to satisfy strict checks

## Testing
- pnpm run typecheck
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d22f2214288322bcdfbc49104034b0