### PR TITLE
feat: restore app shell and estimating panel

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SA CMS Pro</title>
+  </head>
+  <body class="bg-surface text-text-primary">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1512,7 +1512,7 @@ export default function App(): JSX.Element {
 
 
 
-    <div className="rounded-xl border border-danger-soft bg-danger-soft/10 px-4 py-3 text-sm text-danger">
+    <div className="rounded-xl border border-danger-soft bg-danger-soft-10 px-4 py-3 text-sm text-danger">
 
 
 
@@ -1600,7 +1600,7 @@ const intakeView = (
 
 
 
-                  className="w-full rounded-lg border border-border-subtle bg-surface-elevated px-3 py-2 text-sm shadow-panel focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                  className="w-full rounded-lg border border-border-subtle bg-surface-elevated px-3 py-2 text-sm shadow-panel focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent-40"
 
 
 
@@ -1648,7 +1648,7 @@ const intakeView = (
 
 
 
-                  className="w-full rounded-lg border border-border-subtle bg-surface-elevated px-3 py-2 text-sm shadow-panel focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/40"
+                  className="w-full rounded-lg border border-border-subtle bg-surface-elevated px-3 py-2 text-sm shadow-panel focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent-40"
 
 
 
@@ -1700,7 +1700,7 @@ const intakeView = (
 
 
 
-                className="inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast shadow-panel transition hover:bg-accent/90 focus:outline-none focus:ring-2 focus:ring-accent/50 disabled:cursor-not-allowed disabled:opacity-60"
+                className="inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2 text-sm font-semibold text-accent-contrast shadow-panel transition hover:bg-accent-90 focus:outline-none focus:ring-2 focus:ring-accent-50 disabled:cursor-not-allowed disabled:opacity-60"
 
 
 
@@ -2228,7 +2228,7 @@ const intakeView = (
 
 
 
-                className="inline-flex items-center gap-2 rounded-full border border-danger-soft bg-danger-soft/70 px-3 py-1 text-xs font-medium text-danger shadow-panel transition hover:bg-danger-soft disabled:opacity-50"
+                className="inline-flex items-center gap-2 rounded-full border border-danger-soft bg-danger-soft-70 px-3 py-1 text-xs font-medium text-danger shadow-panel transition hover:bg-danger-soft disabled:opacity-50"
 
 
 
@@ -2496,7 +2496,7 @@ const intakeView = (
 
 
 
-                className="inline-flex items-center gap-2 rounded-full bg-success px-4 py-2 text-xs font-semibold text-accent-contrast shadow-panel transition hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex items-center gap-2 rounded-full bg-success px-4 py-2 text-xs font-semibold text-accent-contrast shadow-panel transition hover:bg-success-90 disabled:cursor-not-allowed disabled:opacity-50"
 
 
 
@@ -2592,7 +2592,7 @@ const intakeView = (
 
 
 
-            <div className="fixed inset-0 bg-surface-inset/60" />
+            <div className="fixed inset-0 bg-surface-inset-soft" />
 
 
 
@@ -2804,7 +2804,7 @@ const intakeView = (
 
 
 
-                      <div className="rounded-lg border border-danger-soft bg-danger-soft/70 p-3 text-danger">
+                      <div className="rounded-lg border border-danger-soft bg-danger-soft-70 p-3 text-danger">
 
 
 

--- a/frontend/src/components/dev/TailwindProbe.tsx
+++ b/frontend/src/components/dev/TailwindProbe.tsx
@@ -9,7 +9,7 @@ type StatusChip = {
 const chipClasses =
   "inline-flex items-center gap-2 rounded-full bg-accent px-3 py-1.5 text-xs font-semibold text-accent-contrast shadow-panel transition-transform hover:-translate-y-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
 const badgeClasses =
-  "rounded-full border border-accent-contrast/40 bg-accent-contrast/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-accent-contrast";
+  "rounded-full border border-accent-contrast-40 bg-accent-contrast-20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-accent-contrast";
 
 const statusChips: StatusChip[] = [
   {
@@ -36,7 +36,7 @@ export function TailwindProbe(): JSX.Element {
     <section
       data-testid="tailwind-probe"
       className={clsx(
-        "rounded-3xl border border-accent/50 bg-surface-elevated/90 p-6 text-accent shadow-panel ring-1 ring-accent/20 backdrop-blur"
+        "rounded-3xl border border-accent-50 bg-surface-elevated-90 p-6 text-accent shadow-panel ring-1 ring-accent-20 backdrop-blur"
       )}
     >
       <p className="text-xs font-medium uppercase tracking-[0.2em] text-text-tertiary">
@@ -66,9 +66,9 @@ export function TailwindProbe(): JSX.Element {
       <div className="mt-6 grid gap-4 sm:grid-cols-2">
         <div
           data-testid="tailwind-probe-gradient-card"
-          className="rounded-2xl border border-accent/30 bg-gradient-to-r from-brand-500 via-accent to-brand-700 p-5 text-accent-contrast shadow-shell"
+          className="rounded-2xl border border-accent-30 bg-gradient-to-r from-brand-500 via-accent to-brand-700 p-5 text-accent-contrast shadow-shell"
         >
-          <p className="text-xs uppercase tracking-[0.28em] text-accent-contrast/80">
+          <p className="text-xs uppercase tracking-[0.28em] text-accent-contrast-80">
             Gradient Check
           </p>
           <p className="mt-2 text-sm font-semibold">bg-gradient-to-r | from-brand-500 | via-accent | to-brand-700</p>

--- a/frontend/src/components/estimating/EstimatingPanel.tsx
+++ b/frontend/src/components/estimating/EstimatingPanel.tsx
@@ -1,0 +1,606 @@
+import clsx from "clsx";
+import {
+  adjustEstimatorScenario,
+  createEstimatorScenario,
+  fetchEstimatorSummary,
+  mineEstimatorScope,
+  updateWbsItem,
+  type EstimatorSummary,
+  type Scenario,
+  type WbsItem,
+} from "../../api";
+import {
+  CheckCircle2,
+  Circle,
+  Loader2,
+  Plus,
+  RefreshCcw,
+  Wand2,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+export interface EstimatingPanelProps {
+  className?: string;
+  orgId: string;
+  projectId: string;
+}
+
+interface ScenarioDraftState {
+  names: Record<string, string>;
+  markups: Record<string, Record<string, number>>;
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—";
+  }
+  const percentage = Math.round(value * 100);
+  return `${percentage}%`;
+}
+
+function formatCurrency(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value >= 1000 ? 0 : 2,
+  }).format(value);
+}
+
+function flattenTotals(totals: Scenario["totals"], prefix = ""): Array<{ key: string; value: number }> {
+  const entries: Array<{ key: string; value: number }> = [];
+  for (const [key, value] of Object.entries(totals)) {
+    const nextKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      entries.push({ key: nextKey, value });
+    } else if (value && typeof value === "object") {
+      entries.push(...flattenTotals(value as Scenario["totals"], nextKey));
+    }
+  }
+  return entries;
+}
+
+function calculateGrandTotal(totals: Scenario["totals"]): number {
+  return flattenTotals(totals).reduce((acc, item) => acc + item.value, 0);
+}
+
+const EMPTY_DRAFTS: ScenarioDraftState = { names: {}, markups: {} };
+
+export function EstimatingPanel({ className, orgId, projectId }: EstimatingPanelProps): JSX.Element {
+  const [summary, setSummary] = useState<EstimatorSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [mining, setMining] = useState(false);
+  const [wbsUpdating, setWbsUpdating] = useState<string | null>(null);
+  const [scenarioSaving, setScenarioSaving] = useState<string | null>(null);
+  const [creatingScenario, setCreatingScenario] = useState(false);
+  const [drafts, setDrafts] = useState<ScenarioDraftState>(EMPTY_DRAFTS);
+
+  const syncDrafts = useCallback((scenarios: Scenario[]) => {
+    setDrafts(() => {
+      const nameDrafts: Record<string, string> = {};
+      const markupDrafts: Record<string, Record<string, number>> = {};
+      for (const scenario of scenarios) {
+        nameDrafts[scenario.id] = scenario.name;
+        markupDrafts[scenario.id] = { ...scenario.parameters.markups };
+      }
+      return { names: nameDrafts, markups: markupDrafts };
+    });
+  }, []);
+
+  const loadSummary = useCallback(async () => {
+    if (!orgId || !projectId) {
+      setSummary(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await fetchEstimatorSummary(orgId, projectId);
+      setSummary(payload);
+      syncDrafts(payload.scenarios);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to load estimator summary";
+      setError(message);
+      toast.error(message);
+      setSummary(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, projectId, syncDrafts]);
+
+  useEffect(() => {
+    void loadSummary();
+  }, [loadSummary]);
+
+  const wbsItems = useMemo(() => {
+    if (!summary) {
+      return [] as WbsItem[];
+    }
+    return [...summary.wbs].sort((a, b) => {
+      if (Number.isFinite(a.sequence) && Number.isFinite(b.sequence)) {
+        return a.sequence - b.sequence;
+      }
+      return a.code.localeCompare(b.code);
+    });
+  }, [summary]);
+
+  const acceptedCount = useMemo(() => wbsItems.filter((item) => item.accepted).length, [wbsItems]);
+
+  const handleMineScope = useCallback(async () => {
+    if (!orgId || !projectId) {
+      return;
+    }
+    setMining(true);
+    setError(null);
+    try {
+      const mined = await mineEstimatorScope(orgId, projectId);
+      setSummary((prev) => {
+        const base: EstimatorSummary =
+          prev ?? {
+            org_id: orgId,
+            project_id: projectId,
+            wbs: [],
+            rates: [],
+            scenarios: [],
+          };
+        return { ...base, wbs: mined };
+      });
+      toast.success("Scope mining complete", {
+        description: `${mined.length.toLocaleString()} activities refreshed from project files.`,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Scope mining failed";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setMining(false);
+    }
+  }, [orgId, projectId]);
+
+  const handleToggleAccepted = useCallback(
+    async (item: WbsItem) => {
+      setWbsUpdating(item.id);
+      setError(null);
+      try {
+        const updated = await updateWbsItem(item.id, { accepted: !item.accepted });
+        setSummary((prev) => {
+          if (!prev) {
+            return prev;
+          }
+          return { ...prev, wbs: prev.wbs.map((existing) => (existing.id === updated.id ? updated : existing)) };
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unable to update WBS item";
+        setError(message);
+        toast.error(message);
+      } finally {
+        setWbsUpdating(null);
+      }
+    },
+    [],
+  );
+
+  const handleMarkupDraftChange = useCallback(
+    (scenarioId: string, markupKey: string, rawValue: string) => {
+      const numeric = Number(rawValue);
+      setDrafts((prev) => {
+        const nextNames = { ...prev.names };
+        const nextMarkups = { ...prev.markups };
+        const current = { ...(nextMarkups[scenarioId] ?? {}) };
+        current[markupKey] = Number.isFinite(numeric) ? numeric : 0;
+        nextMarkups[scenarioId] = current;
+        return { names: nextNames, markups: nextMarkups };
+      });
+    },
+    [],
+  );
+
+  const commitScenarioUpdate = useCallback(
+    async (scenarioId: string, payload: Parameters<typeof adjustEstimatorScenario>[1]) => {
+      setScenarioSaving(scenarioId);
+      setError(null);
+      try {
+        const updated = await adjustEstimatorScenario(scenarioId, payload);
+        setSummary((prev) => {
+          if (!prev) {
+            return prev;
+          }
+          const scenarios = prev.scenarios.map((scenario) => (scenario.id === updated.id ? updated : scenario));
+          return { ...prev, scenarios };
+        });
+        setDrafts((prev) => ({
+          names: { ...prev.names, [updated.id]: updated.name },
+          markups: { ...prev.markups, [updated.id]: { ...updated.parameters.markups } },
+        }));
+        toast.success("Scenario updated", { description: updated.name });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to update scenario";
+        setError(message);
+        toast.error(message);
+      } finally {
+        setScenarioSaving(null);
+      }
+    },
+    [],
+  );
+
+  const handleScenarioNameChange = useCallback((scenarioId: string, value: string) => {
+    setDrafts((prev) => ({ names: { ...prev.names, [scenarioId]: value }, markups: { ...prev.markups } }));
+  }, []);
+
+  const handleScenarioNameCommit = useCallback(
+    (scenario: Scenario) => {
+      const draftName = drafts.names[scenario.id]?.trim();
+      const nextName = draftName || scenario.name;
+      if (nextName === scenario.name) {
+        setDrafts((prev) => ({
+          names: { ...prev.names, [scenario.id]: scenario.name },
+          markups: { ...prev.markups },
+        }));
+        return;
+      }
+      void commitScenarioUpdate(scenario.id, { name: nextName });
+    },
+    [commitScenarioUpdate, drafts.names],
+  );
+
+  const handleMarkupCommit = useCallback(
+    (scenario: Scenario, markupKey: string) => {
+      const draftMarkups = drafts.markups[scenario.id];
+      const nextValue = draftMarkups?.[markupKey];
+      const currentValue = scenario.parameters.markups[markupKey];
+      if (nextValue === undefined || nextValue === currentValue) {
+        return;
+      }
+      void commitScenarioUpdate(scenario.id, { parameters: { markups: { [markupKey]: nextValue } } });
+    },
+    [commitScenarioUpdate, drafts.markups],
+  );
+
+  const handleCreateScenario = useCallback(async () => {
+    if (!orgId || !projectId) {
+      return;
+    }
+    setCreatingScenario(true);
+    setError(null);
+    try {
+      const existing = summary?.scenarios ?? [];
+      const payload = await createEstimatorScenario({
+        org_id: orgId,
+        project_id: projectId,
+        name: `Scenario ${existing.length + 1}`,
+      });
+      setSummary((prev) => {
+        const base: EstimatorSummary =
+          prev ?? {
+            org_id: orgId,
+            project_id: projectId,
+            wbs: [],
+            rates: [],
+            scenarios: [],
+          };
+        return { ...base, scenarios: [...base.scenarios, payload] };
+      });
+      setDrafts((prev) => ({
+        names: { ...prev.names, [payload.id]: payload.name },
+        markups: { ...prev.markups, [payload.id]: { ...payload.parameters.markups } },
+      }));
+      toast.success("Scenario created", { description: payload.name });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to create scenario";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setCreatingScenario(false);
+    }
+  }, [orgId, projectId, summary?.scenarios]);
+
+  const scenarioCards = summary?.scenarios ?? [];
+  const rateEntries = summary?.rates ?? [];
+
+  return (
+    <section className={clsx("space-y-6", className)} aria-label="Estimating workspace">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-text-primary">Estimating workspace</h3>
+          <p className="text-xs text-text-secondary">
+            Review mined scope, adjust markups, and compare pricing scenarios before issuing bids.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handleMineScope}
+            disabled={mining || !orgId || !projectId}
+            className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-xs font-semibold text-text-secondary shadow-panel transition hover:bg-surface-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {mining ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : <Wand2 className="h-3.5 w-3.5" aria-hidden />}
+            Mine scope
+          </button>
+          <button
+            type="button"
+            onClick={() => void loadSummary()}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1.5 text-xs font-semibold text-text-secondary shadow-panel transition hover:bg-surface-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+            ) : (
+              <RefreshCcw className="h-3.5 w-3.5" aria-hidden />
+            )}
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={handleCreateScenario}
+            disabled={creatingScenario}
+            className="inline-flex items-center gap-2 rounded-full bg-accent px-4 py-1.5 text-xs font-semibold text-accent-contrast shadow-panel transition hover:bg-accent-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {creatingScenario ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : <Plus className="h-3.5 w-3.5" aria-hidden />}
+            New scenario
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-danger-soft bg-danger-soft-10 px-4 py-3 text-sm text-danger">{error}</div>
+      ) : null}
+
+      {loading && !summary ? (
+        <div className="flex items-center gap-3 rounded-xl border border-border-subtle bg-surface px-4 py-6 text-sm text-text-secondary">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Loading estimator data
+        </div>
+      ) : null}
+
+      {!loading && !summary ? (
+        <div className="rounded-xl border border-border-subtle bg-surface px-4 py-6 text-sm text-text-secondary">
+          Provide a valid organization and project to view estimating data.
+        </div>
+      ) : null}
+
+      {summary ? (
+        <div className="space-y-6">
+          <section className="rounded-xl border border-border-subtle bg-surface shadow-panel" aria-label="Scope breakdown">
+            <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle px-5 py-4">
+              <div>
+                <h4 className="text-sm font-semibold text-text-primary">Work breakdown structure</h4>
+                <p className="text-xs text-text-secondary">
+                  {acceptedCount.toLocaleString()} of {wbsItems.length.toLocaleString()} activities accepted for estimating.
+                </p>
+              </div>
+            </header>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-border-subtle text-left text-sm">
+                <thead className="bg-surface-muted text-xs uppercase tracking-wide text-text-tertiary">
+                  <tr>
+                    <th scope="col" className="px-5 py-3 font-semibold">Code</th>
+                    <th scope="col" className="px-5 py-3 font-semibold">Description</th>
+                    <th scope="col" className="px-5 py-3 font-semibold">Confidence</th>
+                    <th scope="col" className="px-5 py-3 font-semibold">Accepted</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border-subtle">
+                  {wbsItems.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-5 py-6 text-center text-sm text-text-secondary">
+                        No scope items available. Run scope mining to populate the estimator.
+                      </td>
+                    </tr>
+                  ) : (
+                    wbsItems.map((item) => {
+                      const isUpdating = wbsUpdating === item.id;
+                      return (
+                        <tr key={item.id} className="align-top">
+                          <td className="px-5 py-4 text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+                            {item.code || "—"}
+                          </td>
+                          <td className="px-5 py-4">
+                            <div className="text-sm font-medium text-text-primary">{item.description}</div>
+                            <div className="mt-1 text-xs text-text-secondary">Sequence {item.sequence}</div>
+                          </td>
+                          <td className="px-5 py-4">
+                            <span className="inline-flex items-center rounded-full bg-surface-inset px-2.5 py-0.5 text-xs font-medium text-text-secondary">
+                              {formatPercent(item.confidence)}
+                            </span>
+                          </td>
+                          <td className="px-5 py-4">
+                            <button
+                              type="button"
+                              onClick={() => void handleToggleAccepted(item)}
+                              disabled={isUpdating}
+                              className="inline-flex items-center gap-2 rounded-full border border-border-subtle bg-surface px-3 py-1 text-xs font-medium text-text-secondary shadow-panel transition hover:bg-surface-muted disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {item.accepted ? (
+                                <CheckCircle2 className="h-4 w-4 text-success" aria-hidden />
+                              ) : (
+                                <Circle className="h-4 w-4 text-text-tertiary" aria-hidden />
+                              )}
+                              {isUpdating ? "Saving" : item.accepted ? "Accepted" : "Review"}
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="space-y-4" aria-label="Scenario planning">
+            <header className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h4 className="text-sm font-semibold text-text-primary">Pricing scenarios</h4>
+                <p className="text-xs text-text-secondary">Adjust markups to compare bid-ready totals.</p>
+              </div>
+            </header>
+            {scenarioCards.length === 0 ? (
+              <div className="rounded-xl border border-border-subtle bg-surface px-4 py-6 text-sm text-text-secondary">
+                No scenarios available. Create a new scenario to begin estimating.
+              </div>
+            ) : (
+              <div className="grid gap-5 lg:grid-cols-2">
+                {scenarioCards.map((scenario) => {
+                  const markupDraft = drafts.markups[scenario.id] ?? scenario.parameters.markups;
+                  const nameDraft = drafts.names[scenario.id] ?? scenario.name;
+                  const totals = flattenTotals(scenario.totals);
+                  const grandTotal = calculateGrandTotal(scenario.totals);
+                  const isSaving = scenarioSaving === scenario.id;
+                  return (
+                    <article
+                      key={scenario.id}
+                      className="flex flex-col gap-4 rounded-xl border border-border-subtle bg-surface shadow-panel"
+                    >
+                      <div className="flex flex-col gap-3 border-b border-border-subtle px-5 py-4">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex-1">
+                            <label className="text-xs font-semibold uppercase tracking-wide text-text-tertiary" htmlFor={`scenario-${scenario.id}`}>
+                              Scenario name
+                            </label>
+                            <input
+                              id={`scenario-${scenario.id}`}
+                              value={nameDraft}
+                              onChange={(event) => handleScenarioNameChange(scenario.id, event.target.value)}
+                              onBlur={() => handleScenarioNameCommit(scenario)}
+                              onKeyDown={(event) => {
+                                if (event.key === "Enter") {
+                                  event.currentTarget.blur();
+                                }
+                              }}
+                              className="mt-1 w-full rounded-lg border border-border-subtle bg-surface px-3 py-2 text-sm font-semibold text-text-primary shadow-panel focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent-30"
+                            />
+                          </div>
+                          <div className="text-right">
+                            <div className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">Grand total</div>
+                            <div className="text-base font-semibold text-text-primary">{formatCurrency(grandTotal)}</div>
+                          </div>
+                        </div>
+                        {isSaving ? (
+                          <div className="flex items-center gap-2 text-xs text-text-secondary">
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> Saving updates
+                          </div>
+                        ) : null}
+                      </div>
+                      <div className="grid gap-4 px-5 pb-5">
+                        <div className="space-y-3">
+                          <h5 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">Markups</h5>
+                          <div className="space-y-3">
+                            {Object.keys(markupDraft).length === 0 ? (
+                              <p className="rounded-lg border border-border-subtle bg-surface px-3 py-2 text-xs text-text-secondary">
+                                No markups defined for this scenario.
+                              </p>
+                            ) : (
+                              Object.entries(markupDraft).map(([key, value]) => (
+                                <div key={key} className="flex items-center justify-between gap-3">
+                                  <label className="text-sm font-medium text-text-primary" htmlFor={`markup-${scenario.id}-${key}`}>
+                                    {key.replace(/_/g, " ")}
+                                  </label>
+                                  <div className="flex items-center gap-2">
+                                    <input
+                                      id={`markup-${scenario.id}-${key}`}
+                                      type="number"
+                                      value={value}
+                                      onChange={(event) => handleMarkupDraftChange(scenario.id, key, event.target.value)}
+                                      onBlur={() => handleMarkupCommit(scenario, key)}
+                                      onKeyDown={(event) => {
+                                        if (event.key === "Enter") {
+                                          event.currentTarget.blur();
+                                        }
+                                      }}
+                                      step={0.1}
+                                      className="w-24 rounded-lg border border-border-subtle bg-surface px-2 py-1 text-right text-sm text-text-primary shadow-panel focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent-30"
+                                    />
+                                    <span className="text-xs text-text-secondary">%</span>
+                                  </div>
+                                </div>
+                              ))
+                            )}
+                          </div>
+                        </div>
+                        <div className="space-y-3">
+                          <h5 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">Totals</h5>
+                          <div className="space-y-2">
+                            {totals.length === 0 ? (
+                              <p className="rounded-lg border border-border-subtle bg-surface px-3 py-2 text-xs text-text-secondary">
+                                Totals unavailable for this scenario.
+                              </p>
+                            ) : (
+                              totals.map((entry) => (
+                                <div key={entry.key} className="flex items-center justify-between gap-3 text-sm">
+                                  <span className="text-text-secondary">{entry.key.replace(/\./g, " › ")}</span>
+                                  <span className="font-semibold text-text-primary">{formatCurrency(entry.value)}</span>
+                                </div>
+                              ))
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-xl border border-border-subtle bg-surface shadow-panel" aria-label="Rate reference">
+            <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle px-5 py-4">
+              <div>
+                <h4 className="text-sm font-semibold text-text-primary">Crew and trade rates</h4>
+                <p className="text-xs text-text-secondary">
+                  Baseline labor and material assumptions pulled from the estimating library.
+                </p>
+              </div>
+            </header>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-border-subtle text-left text-sm">
+                <thead className="bg-surface-muted text-xs uppercase tracking-wide text-text-tertiary">
+                  <tr>
+                    <th scope="col" className="px-5 py-3 font-semibold">Category</th>
+                    <th scope="col" className="px-5 py-3 font-semibold">CSI</th>
+                    <th scope="col" className="px-5 py-3 font-semibold">Base rate</th>
+                    <th scope="col" className="px-5 py-3 font-semibold">Range</th>
+                    <th scope="col" className="px-5 py-3 font-semibold">Confidence</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border-subtle">
+                  {rateEntries.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="px-5 py-6 text-center text-sm text-text-secondary">
+                        Rate library not available. Confirm estimator services are online.
+                      </td>
+                    </tr>
+                  ) : (
+                    rateEntries.map((rate) => (
+                      <tr key={rate.id}>
+                        <td className="px-5 py-4">
+                          <div className="text-sm font-medium text-text-primary">{rate.category}</div>
+                          <div className="text-xs text-text-secondary">{rate.metadata?.region ?? "Standard region"}</div>
+                        </td>
+                        <td className="px-5 py-4 text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+                          {rate.csi_code || "—"}
+                        </td>
+                        <td className="px-5 py-4 font-semibold text-text-primary">{formatCurrency(rate.base_rate)}</td>
+                        <td className="px-5 py-4 text-sm text-text-secondary">
+                          {formatCurrency(rate.low_rate)} – {formatCurrency(rate.high_rate)}
+                        </td>
+                        <td className="px-5 py-4">
+                          <span className="inline-flex items-center rounded-full bg-surface-inset px-2.5 py-0.5 text-xs font-medium text-text-secondary">
+                            {formatPercent(rate.confidence)}
+                          </span>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/estimating/index.ts
+++ b/frontend/src/components/estimating/index.ts
@@ -1,0 +1,1 @@
+export * from "./EstimatingPanel";

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1,0 +1,198 @@
+import clsx from "clsx";
+import { Moon, Sun } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { OrgSummary } from "./OrgSummary";
+import { UserBadge } from "./UserBadge";
+
+export type AppShellNavTone = "neutral" | "accent" | "warning" | "success" | "danger";
+
+export interface AppShellNavItem {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: ReactNode;
+  badge?: ReactNode;
+  tone?: AppShellNavTone;
+  disabled?: boolean;
+}
+
+export interface AppShellUser {
+  name: string;
+  title?: string | null;
+  initials?: string | null;
+}
+
+export interface AppShellOrg {
+  name: string;
+  code?: string | null;
+}
+
+export interface AppShellProject {
+  name: string;
+  code?: string | null;
+  stage?: string | null;
+}
+
+export interface AppShellProps {
+  children: ReactNode;
+  navItems: AppShellNavItem[];
+  activeItem?: string | null;
+  onSelect: (id: string) => void;
+  theme: "light" | "dark";
+  onToggleTheme?: () => void;
+  user?: AppShellUser | null;
+  org?: AppShellOrg | null;
+  project?: AppShellProject | null;
+  rightRail?: ReactNode;
+}
+
+const BADGE_TONE_CLASSES: Record<AppShellNavTone, string> = {
+  neutral: "bg-surface-inset text-text-secondary",
+  accent: "bg-accent-soft text-accent",
+  warning: "bg-warning-soft text-warning",
+  success: "bg-success-soft text-success",
+  danger: "bg-danger-soft text-danger",
+};
+
+const ACTIVE_NAV_CLASSES =
+  "bg-surface px-3 py-3 ring-1 ring-border-strong shadow-panel text-text-primary";
+const INACTIVE_NAV_CLASSES =
+  "bg-transparent px-3 py-3 text-text-secondary hover:bg-surface-soft hover:text-text-primary";
+
+export function AppShell({
+  children,
+  navItems,
+  activeItem,
+  onSelect,
+  theme,
+  onToggleTheme,
+  user,
+  org,
+  project,
+  rightRail,
+}: AppShellProps): JSX.Element {
+  const workspaceTitle = project?.name || "Project workspace";
+  const workspaceCode = project?.code;
+  const workspaceStage = project?.stage;
+  const organizationName = org?.name || "Workspace";
+  const organizationCode = org?.code;
+
+  const handleSelect = (item: AppShellNavItem) => {
+    if (!item.disabled) {
+      onSelect(item.id);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen bg-surface text-text-primary">
+      <aside
+        className="hidden w-72 flex-shrink-0 flex-col border-r border-border-subtle bg-surface-elevated lg:flex"
+        aria-label="Primary navigation"
+      >
+        <div className="flex h-16 items-center px-6 text-sm font-semibold uppercase tracking-wide text-text-tertiary">
+          SA CMS
+        </div>
+        <nav className="flex-1 overflow-y-auto px-3 pb-6">
+          <ul className="flex flex-col gap-2">
+            {navItems.map((item) => {
+              const isActive = item.id === activeItem;
+              const tone = item.tone ?? "neutral";
+              const badgeClass = BADGE_TONE_CLASSES[tone];
+              return (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(item)}
+                    className={clsx(
+                      "group w-full rounded-xl text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                      item.disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+                      isActive ? ACTIVE_NAV_CLASSES : INACTIVE_NAV_CLASSES,
+                    )}
+                    aria-current={isActive ? "page" : undefined}
+                    disabled={item.disabled}
+                  >
+                    <div className="flex items-center gap-3">
+                      {item.icon ? (
+                        <span className={clsx("flex h-9 w-9 items-center justify-center rounded-full text-text-tertiary", isActive ? "bg-surface-inset" : "bg-surface-muted")}>{item.icon}</span>
+                      ) : null}
+                      <div className="flex flex-1 flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                          <span className={clsx("text-sm font-semibold", isActive ? "text-text-primary" : "text-text-secondary")}>{item.label}</span>
+                          {item.badge ? (
+                            <span className={clsx(
+                              "inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-medium",
+                              badgeClass,
+                            )}
+                            >
+                              {item.badge}
+                            </span>
+                          ) : null}
+                        </div>
+                        {item.description ? (
+                          <p className="text-xs text-text-tertiary line-clamp-2">{item.description}</p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+        <div className="border-t border-border-subtle p-5">
+          <OrgSummary org={org} project={project} />
+        </div>
+      </aside>
+      <div className="flex min-h-screen flex-1 flex-col">
+        <header className="flex flex-col gap-4 border-b border-border-subtle bg-surface-elevated px-4 py-4 md:flex-row md:items-center md:justify-between md:px-8">
+          <div className="space-y-2">
+            <div className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">{organizationName}</div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-base font-semibold text-text-primary">{workspaceTitle}</h1>
+              {workspaceCode ? (
+                <span className="inline-flex items-center rounded-full bg-surface-inset px-2.5 py-0.5 text-xs font-medium text-text-secondary">
+                  {workspaceCode}
+                </span>
+              ) : null}
+              {workspaceStage ? (
+                <span className="inline-flex items-center rounded-full bg-accent-soft px-2.5 py-0.5 text-xs font-medium text-accent">
+                  {workspaceStage}
+                </span>
+              ) : null}
+              {organizationCode ? (
+                <span className="inline-flex items-center rounded-full bg-surface px-2.5 py-0.5 text-xs font-medium text-text-tertiary">
+                  {organizationCode}
+                </span>
+              ) : null}
+            </div>
+            <p className="text-xs text-text-secondary">
+              Review program modules, monitor status, and coordinate estimating and intake workflows inside the SA CMS workspace.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={onToggleTheme}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border-subtle bg-surface text-text-secondary shadow-panel transition hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+            >
+              {theme === "dark" ? <Sun className="h-4 w-4" aria-hidden /> : <Moon className="h-4 w-4" aria-hidden />}
+            </button>
+            <UserBadge user={user} />
+          </div>
+        </header>
+        <div className="flex flex-1 overflow-hidden">
+          <main className="flex-1 overflow-y-auto px-4 py-6 md:px-8 md:py-10">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">{children}</div>
+          </main>
+          {rightRail ? (
+            <aside className="hidden w-80 flex-shrink-0 overflow-y-auto border-l border-border-subtle bg-surface-elevated px-5 py-6 lg:block">
+              <div className="space-y-6">{rightRail}</div>
+            </aside>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/OrgSummary.tsx
+++ b/frontend/src/components/shell/OrgSummary.tsx
@@ -1,0 +1,48 @@
+import clsx from "clsx";
+
+import type { AppShellOrg, AppShellProject } from "./AppShell";
+
+export interface OrgSummaryProps {
+  org?: AppShellOrg | null;
+  project?: AppShellProject | null;
+  className?: string;
+}
+
+export function OrgSummary({ org, project, className }: OrgSummaryProps): JSX.Element {
+  const orgName = org?.name ?? "—";
+  const orgCode = org?.code;
+  const projectName = project?.name ?? "—";
+  const projectCode = project?.code;
+  const projectStage = project?.stage;
+
+  return (
+    <div className={clsx("space-y-4 text-sm", className)}>
+      <div className="space-y-1">
+        <div className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">Organization</div>
+        <div className="text-sm font-semibold text-text-primary">{orgName}</div>
+        {orgCode ? (
+          <span className="inline-flex items-center rounded-full bg-surface px-2.5 py-0.5 text-xs font-medium text-text-secondary">
+            {orgCode}
+          </span>
+        ) : null}
+      </div>
+      <div className="space-y-2">
+        <div className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">Project</div>
+        <div className="text-sm font-semibold text-text-primary">{projectName}</div>
+        <div className="flex flex-wrap items-center gap-2">
+          {projectCode ? (
+            <span className="inline-flex items-center rounded-full bg-surface-inset px-2.5 py-0.5 text-xs font-medium text-text-secondary">
+              {projectCode}
+            </span>
+          ) : null}
+          {projectStage ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-accent-soft px-2.5 py-0.5 text-xs font-medium text-accent">
+              <span className="h-1.5 w-1.5 rounded-full bg-accent" aria-hidden />
+              {projectStage}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/UserBadge.tsx
+++ b/frontend/src/components/shell/UserBadge.tsx
@@ -1,0 +1,51 @@
+import clsx from "clsx";
+
+import type { AppShellUser } from "./AppShell";
+
+export interface UserBadgeProps {
+  user?: AppShellUser | null;
+  className?: string;
+}
+
+function deriveInitials(name?: string | null, fallback = "SA"): string {
+  if (!name) {
+    return fallback;
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    return fallback;
+  }
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toUpperCase() || fallback;
+  }
+  const initials = `${parts[0]![0] ?? ""}${parts[1]![0] ?? ""}`.toUpperCase();
+  return initials || trimmed.slice(0, 2).toUpperCase() || fallback;
+}
+
+export function UserBadge({ user, className }: UserBadgeProps): JSX.Element {
+  const displayName = user?.name?.trim() || "Signed out";
+  const displayTitle = user?.title?.trim() || "Operator";
+  const initials = user?.initials?.trim() || deriveInitials(user?.name);
+
+  return (
+    <div
+      className={clsx(
+        "inline-flex items-center gap-3 rounded-full border border-border-subtle bg-surface px-3 py-2 shadow-panel",
+        className,
+      )}
+      aria-label={`Signed in as ${displayName}`}
+    >
+      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-accent text-sm font-semibold text-accent-contrast">
+        {initials}
+      </span>
+      <div className="flex flex-col leading-tight">
+        <span className="text-sm font-semibold text-text-primary">{displayName}</span>
+        <span className="text-xs text-text-secondary">{displayTitle}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/index.ts
+++ b/frontend/src/components/shell/index.ts
@@ -1,0 +1,3 @@
+export * from "./AppShell";
+export * from "./OrgSummary";
+export * from "./UserBadge";

--- a/frontend/src/components/upload/UploadPanel.tsx
+++ b/frontend/src/components/upload/UploadPanel.tsx
@@ -213,7 +213,7 @@ export function UploadPanel({ className, projectId }: UploadPanelProps): JSX.Ele
         </div>
       </div>
 
-      <div className="rounded-xl border border-border-subtle bg-surface-muted/60 p-4 shadow-panel space-y-3">
+      <div className="rounded-xl border border-border-subtle bg-surface-muted-soft p-4 shadow-panel space-y-3">
         <div className="flex flex-wrap items-center justify-between text-xs text-text-secondary">
           <span>
             {totalFiles} file{totalFiles === 1 ? '' : 's'} in queue

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,308 @@
+@config "../tailwind.config.ts";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  --color-surface: 248 250 252;
+  --color-surface-elevated: 255 255 255;
+  --color-surface-muted: 241 245 249;
+  --color-surface-inset: 226 232 240;
+  --color-text-primary: 15 23 42;
+  --color-text-secondary: 71 85 105;
+  --color-text-tertiary: 100 116 139;
+  --color-accent: 59 130 246;
+  --color-accent-soft: 219 234 254;
+  --color-accent-contrast: 255 255 255;
+  --color-border-subtle: 226 232 240;
+  --color-border-strong: 148 163 184;
+  --color-success: 34 197 94;
+  --color-success-soft: 220 252 231;
+  --color-warning: 245 158 11;
+  --color-warning-soft: 254 243 199;
+  --color-danger: 239 68 68;
+  --color-danger-soft: 254 226 226;
+  --color-brand-500: 99 102 241;
+  --color-brand-700: 67 56 202;
+  --shadow-panel: 0 18px 36px -20px rgba(15, 23, 42, 0.35);
+  --shadow-shell: 0 32px 64px -28px rgba(15, 23, 42, 0.42);
+}
+
+.dark {
+  color-scheme: dark;
+  --color-surface: 11 17 26;
+  --color-surface-elevated: 15 23 42;
+  --color-surface-muted: 24 34 52;
+  --color-surface-inset: 36 50 77;
+  --color-text-primary: 241 245 249;
+  --color-text-secondary: 148 163 184;
+  --color-text-tertiary: 100 116 139;
+  --color-accent: 96 165 250;
+  --color-accent-soft: 37 99 235;
+  --color-accent-contrast: 255 255 255;
+  --color-border-subtle: 51 65 85;
+  --color-border-strong: 71 85 105;
+  --color-success: 34 197 94;
+  --color-success-soft: 34 197 94;
+  --color-warning: 245 158 11;
+  --color-warning-soft: 245 158 11;
+  --color-danger: 239 68 68;
+  --color-danger-soft: 239 68 68;
+  --color-brand-500: 99 102 241;
+  --color-brand-700: 79 70 229;
+  --shadow-panel: 0 22px 48px -20px rgba(2, 6, 23, 0.65);
+  --shadow-shell: 0 36px 72px -28px rgba(2, 6, 23, 0.7);
+}
+
+@layer base {
+  body {
+    @apply bg-surface text-text-primary antialiased;
+  }
+}
+
+@layer utilities {
+  .text-balance {
+    text-wrap: balance;
+  }
+
+  .bg-surface {
+    background-color: rgb(var(--color-surface) / 1);
+  }
+
+  .bg-surface-soft {
+    background-color: rgb(var(--color-surface) / 0.6);
+  }
+
+  .bg-surface-muted {
+    background-color: rgb(var(--color-surface-muted) / 1);
+  }
+
+  .bg-surface-muted-soft {
+    background-color: rgb(var(--color-surface-muted) / 0.6);
+  }
+
+  .bg-surface-elevated {
+    background-color: rgb(var(--color-surface-elevated) / 1);
+  }
+
+  .bg-surface-elevated-90 {
+    background-color: rgb(var(--color-surface-elevated) / 0.9);
+  }
+
+  .bg-surface-inset {
+    background-color: rgb(var(--color-surface-inset) / 1);
+  }
+
+  .bg-surface-inset-soft {
+    background-color: rgb(var(--color-surface-inset) / 0.6);
+  }
+
+  .bg-accent {
+    background-color: rgb(var(--color-accent) / 1);
+  }
+
+  .bg-accent-90 {
+    background-color: rgb(var(--color-accent) / 0.9);
+  }
+
+  .bg-accent-soft {
+    background-color: rgb(var(--color-accent-soft) / 1);
+  }
+
+  .bg-accent-contrast-20 {
+    background-color: rgb(var(--color-accent-contrast) / 0.2);
+  }
+
+  .bg-success {
+    background-color: rgb(var(--color-success) / 1);
+  }
+
+  .bg-success-90 {
+    background-color: rgb(var(--color-success) / 0.9);
+  }
+
+  .bg-success-soft {
+    background-color: rgb(var(--color-success-soft) / 1);
+  }
+
+  .bg-warning {
+    background-color: rgb(var(--color-warning) / 1);
+  }
+
+  .bg-warning-soft {
+    background-color: rgb(var(--color-warning-soft) / 1);
+  }
+
+  .bg-danger {
+    background-color: rgb(var(--color-danger) / 1);
+  }
+
+  .bg-danger-soft {
+    background-color: rgb(var(--color-danger-soft) / 1);
+  }
+
+  .bg-danger-soft-10 {
+    background-color: rgb(var(--color-danger-soft) / 0.1);
+  }
+
+  .bg-danger-soft-70 {
+    background-color: rgb(var(--color-danger-soft) / 0.7);
+  }
+
+  .bg-brand-500 {
+    background-color: rgb(var(--color-brand-500) / 1);
+  }
+
+  .bg-brand-700 {
+    background-color: rgb(var(--color-brand-700) / 1);
+  }
+
+  .text-text-primary {
+    color: rgb(var(--color-text-primary) / 1);
+  }
+
+  .text-text-secondary {
+    color: rgb(var(--color-text-secondary) / 1);
+  }
+
+  .text-text-tertiary {
+    color: rgb(var(--color-text-tertiary) / 1);
+  }
+
+  .text-accent {
+    color: rgb(var(--color-accent) / 1);
+  }
+
+  .text-accent-contrast {
+    color: rgb(var(--color-accent-contrast) / 1);
+  }
+
+  .text-accent-contrast-80 {
+    color: rgb(var(--color-accent-contrast) / 0.8);
+  }
+
+  .text-success {
+    color: rgb(var(--color-success) / 1);
+  }
+
+  .text-warning {
+    color: rgb(var(--color-warning) / 1);
+  }
+
+  .text-danger {
+    color: rgb(var(--color-danger) / 1);
+  }
+
+  .border-border-subtle {
+    border-color: rgb(var(--color-border-subtle) / 1);
+  }
+
+  .border-border-strong {
+    border-color: rgb(var(--color-border-strong) / 1);
+  }
+
+  .border-accent {
+    border-color: rgb(var(--color-accent) / 1);
+  }
+
+  .border-accent-30 {
+    border-color: rgb(var(--color-accent) / 0.3);
+  }
+
+  .border-accent-50 {
+    border-color: rgb(var(--color-accent) / 0.5);
+  }
+
+  .border-accent-contrast-40 {
+    border-color: rgb(var(--color-accent-contrast) / 0.4);
+  }
+
+  .border-danger-soft {
+    border-color: rgb(var(--color-danger-soft) / 1);
+  }
+
+  .divide-border-subtle > :not([hidden]) ~ :not([hidden]) {
+    --tw-divide-y-reverse: 0;
+    border-color: rgb(var(--color-border-subtle) / 1);
+  }
+
+  .ring-accent {
+    --tw-ring-color: rgb(var(--color-accent) / 1);
+  }
+
+  .ring-accent-20 {
+    --tw-ring-color: rgb(var(--color-accent) / 0.2);
+  }
+
+  .ring-accent-30 {
+    --tw-ring-color: rgb(var(--color-accent) / 0.3);
+  }
+
+  .ring-accent-40 {
+    --tw-ring-color: rgb(var(--color-accent) / 0.4);
+  }
+
+  .ring-accent-50 {
+    --tw-ring-color: rgb(var(--color-accent) / 0.5);
+  }
+
+  .focus\:ring-accent-30:focus {
+    --tw-ring-color: rgb(var(--color-accent) / 0.3);
+  }
+
+  .focus\:ring-accent-40:focus {
+    --tw-ring-color: rgb(var(--color-accent) / 0.4);
+  }
+
+  .focus\:ring-accent-50:focus {
+    --tw-ring-color: rgb(var(--color-accent) / 0.5);
+  }
+
+  .focus-visible\:ring-accent:focus-visible {
+    --tw-ring-color: rgb(var(--color-accent) / 1);
+  }
+
+  .hover\:bg-accent-90:hover {
+    background-color: rgb(var(--color-accent) / 0.9);
+  }
+
+  .hover\:bg-success-90:hover {
+    background-color: rgb(var(--color-success) / 0.9);
+  }
+
+  .hover\:bg-surface-soft:hover {
+    background-color: rgb(var(--color-surface) / 0.6);
+  }
+
+  .hover\:bg-surface-muted:hover {
+    background-color: rgb(var(--color-surface-muted) / 1);
+  }
+
+  .hover\:bg-danger-soft:hover {
+    background-color: rgb(var(--color-danger-soft) / 1);
+  }
+
+  .shadow-panel {
+    box-shadow: var(--shadow-panel);
+  }
+
+  .shadow-shell {
+    box-shadow: var(--shadow-shell);
+  }
+
+  .from-brand-500 {
+    --tw-gradient-from: rgb(var(--color-brand-500)) var(--tw-gradient-from-position);
+    --tw-gradient-to: rgb(var(--color-brand-500) / 0);
+    --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+  }
+
+  .via-accent {
+    --tw-gradient-stops: var(--tw-gradient-from),
+      rgb(var(--color-accent)) var(--tw-gradient-via-position), var(--tw-gradient-to);
+  }
+
+  .to-brand-700 {
+    --tw-gradient-to: rgb(var(--color-brand-700)) var(--tw-gradient-to-position);
+  }
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,124 @@
+import type { Config } from "tailwindcss";
+
+const withOpacity = (variable: string) => {
+  return ({ opacityValue }: { opacityValue?: string }) => {
+    if (opacityValue !== undefined) {
+      return `rgb(var(${variable}) / ${opacityValue})`;
+    }
+    return `rgb(var(${variable}))`;
+  };
+};
+
+const semanticUtilities = ({
+  addUtilities,
+}: {
+  addUtilities: (utilities: Record<string, Record<string, string>>) => void;
+}) => {
+  addUtilities({
+    ".bg-surface": { backgroundColor: "rgb(var(--color-surface) / 1)" },
+    ".bg-surface-soft": { backgroundColor: "rgb(var(--color-surface) / 0.6)" },
+    ".bg-surface-muted": { backgroundColor: "rgb(var(--color-surface-muted) / 1)" },
+    ".bg-surface-muted-soft": { backgroundColor: "rgb(var(--color-surface-muted) / 0.6)" },
+    ".bg-surface-elevated": { backgroundColor: "rgb(var(--color-surface-elevated) / 1)" },
+    ".bg-surface-elevated-90": { backgroundColor: "rgb(var(--color-surface-elevated) / 0.9)" },
+    ".bg-surface-inset": { backgroundColor: "rgb(var(--color-surface-inset) / 1)" },
+    ".bg-surface-inset-soft": { backgroundColor: "rgb(var(--color-surface-inset) / 0.6)" },
+    ".bg-accent": { backgroundColor: "rgb(var(--color-accent) / 1)" },
+    ".bg-accent-90": { backgroundColor: "rgb(var(--color-accent) / 0.9)" },
+    ".bg-accent-soft": { backgroundColor: "rgb(var(--color-accent-soft) / 1)" },
+    ".bg-accent-contrast-20": { backgroundColor: "rgb(var(--color-accent-contrast) / 0.2)" },
+    ".bg-success": { backgroundColor: "rgb(var(--color-success) / 1)" },
+    ".bg-success-90": { backgroundColor: "rgb(var(--color-success) / 0.9)" },
+    ".bg-success-soft": { backgroundColor: "rgb(var(--color-success-soft) / 1)" },
+    ".bg-warning": { backgroundColor: "rgb(var(--color-warning) / 1)" },
+    ".bg-warning-soft": { backgroundColor: "rgb(var(--color-warning-soft) / 1)" },
+    ".bg-danger": { backgroundColor: "rgb(var(--color-danger) / 1)" },
+    ".bg-danger-soft": { backgroundColor: "rgb(var(--color-danger-soft) / 1)" },
+    ".bg-danger-soft-10": { backgroundColor: "rgb(var(--color-danger-soft) / 0.1)" },
+    ".bg-danger-soft-70": { backgroundColor: "rgb(var(--color-danger-soft) / 0.7)" },
+    ".bg-brand-500": { backgroundColor: "rgb(var(--color-brand-500) / 1)" },
+    ".bg-brand-700": { backgroundColor: "rgb(var(--color-brand-700) / 1)" },
+    ".text-text-primary": { color: "rgb(var(--color-text-primary) / 1)" },
+    ".text-text-secondary": { color: "rgb(var(--color-text-secondary) / 1)" },
+    ".text-text-tertiary": { color: "rgb(var(--color-text-tertiary) / 1)" },
+    ".text-accent": { color: "rgb(var(--color-accent) / 1)" },
+    ".text-accent-contrast": { color: "rgb(var(--color-accent-contrast) / 1)" },
+    ".text-accent-contrast-80": { color: "rgb(var(--color-accent-contrast) / 0.8)" },
+    ".text-success": { color: "rgb(var(--color-success) / 1)" },
+    ".text-warning": { color: "rgb(var(--color-warning) / 1)" },
+    ".text-danger": { color: "rgb(var(--color-danger) / 1)" },
+    ".border-border-subtle": { borderColor: "rgb(var(--color-border-subtle) / 1)" },
+    ".border-border-strong": { borderColor: "rgb(var(--color-border-strong) / 1)" },
+    ".border-accent": { borderColor: "rgb(var(--color-accent) / 1)" },
+    ".border-accent-30": { borderColor: "rgb(var(--color-accent) / 0.3)" },
+    ".border-accent-50": { borderColor: "rgb(var(--color-accent) / 0.5)" },
+    ".border-accent-contrast-40": { borderColor: "rgb(var(--color-accent-contrast) / 0.4)" },
+    ".border-danger-soft": { borderColor: "rgb(var(--color-danger-soft) / 1)" },
+    ".divide-border-subtle > :not([hidden]) ~ :not([hidden])": {
+      "--tw-divide-y-reverse": "0",
+      borderColor: "rgb(var(--color-border-subtle) / 1)",
+    },
+    ".ring-accent": { "--tw-ring-color": "rgb(var(--color-accent) / 1)" },
+    ".ring-accent-20": { "--tw-ring-color": "rgb(var(--color-accent) / 0.2)" },
+    ".ring-accent-30": { "--tw-ring-color": "rgb(var(--color-accent) / 0.3)" },
+    ".ring-accent-40": { "--tw-ring-color": "rgb(var(--color-accent) / 0.4)" },
+    ".ring-accent-50": { "--tw-ring-color": "rgb(var(--color-accent) / 0.5)" },
+    ".shadow-panel": { boxShadow: "var(--shadow-panel)" },
+    ".shadow-shell": { boxShadow: "var(--shadow-shell)" },
+    ".from-brand-500": {
+      "--tw-gradient-from": "rgb(var(--color-brand-500)) var(--tw-gradient-from-position)",
+      "--tw-gradient-to": "rgb(var(--color-brand-500) / 0)",
+      "--tw-gradient-stops": "var(--tw-gradient-from), var(--tw-gradient-to)",
+    },
+    ".via-accent": {
+      "--tw-gradient-stops":
+        "var(--tw-gradient-from), rgb(var(--color-accent)) var(--tw-gradient-via-position), var(--tw-gradient-to)",
+    },
+    ".to-brand-700": {
+      "--tw-gradient-to": "rgb(var(--color-brand-700)) var(--tw-gradient-to-position)",
+    },
+  });
+};
+
+const config: Config = {
+  darkMode: "class",
+  content: ["./index.html", "./tailwind-probe.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        surface: withOpacity("--color-surface"),
+        "surface-muted": withOpacity("--color-surface-muted"),
+        "surface-elevated": withOpacity("--color-surface-elevated"),
+        "surface-inset": withOpacity("--color-surface-inset"),
+        accent: withOpacity("--color-accent"),
+        "accent-soft": withOpacity("--color-accent-soft"),
+        "accent-contrast": withOpacity("--color-accent-contrast"),
+        "text-primary": withOpacity("--color-text-primary"),
+        "text-secondary": withOpacity("--color-text-secondary"),
+        "text-tertiary": withOpacity("--color-text-tertiary"),
+        "border-subtle": withOpacity("--color-border-subtle"),
+        "border-strong": withOpacity("--color-border-strong"),
+        success: withOpacity("--color-success"),
+        "success-soft": withOpacity("--color-success-soft"),
+        warning: withOpacity("--color-warning"),
+        "warning-soft": withOpacity("--color-warning-soft"),
+        danger: withOpacity("--color-danger"),
+        "danger-soft": withOpacity("--color-danger-soft"),
+        brand: {
+          500: withOpacity("--color-brand-500"),
+          700: withOpacity("--color-brand-700"),
+        },
+      },
+      boxShadow: {
+        panel: "var(--shadow-panel)",
+        shell: "var(--shadow-shell)",
+      },
+      ringColor: {
+        accent: withOpacity("--color-accent"),
+      },
+    },
+  },
+  plugins: [semanticUtilities],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- rebuild the AppShell layout with new OrgSummary and UserBadge subcomponents and semantic tokens
- reintroduce the EstimatingPanel wired to estimator APIs and refresh shell consumers to the new utility names
- add Tailwind theme configuration, shared index.html, and supporting CSS utilities for semantic colors

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d231c44ce88322bc3d8c2bbf36aa2d